### PR TITLE
Report failed builds in console

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -92,7 +92,15 @@ export default {
       var pair = lang + "/" + version;
       console.log("Querying data for", lang, version, pair);
       fetch("https://raw.githubusercontent.com/kaitai-io/ci_artifacts/" + pair + "/test_out/" + lang + "/ci.json").then(r =>
-        r.json()
+        if (r.ok) {
+          return r.json;
+        } else {
+          errorJson =
+            {
+              "$meta": "Build failure"
+            }
+          return errorJson;
+        }
       ).then(json => {
         var meta = json.$meta;
         delete json['$meta'];


### PR DESCRIPTION
If the build fails, no .json file is produced, like here.
https://github.com/kaitai-io/ci_artifacts/tree/ad445b82c6c648df01d5a3b347f67216f60e4647/test_out/cpp_stl_98
Failure to parse the JSON prevents the whole column from being rendered. This commit
doesn't fix rendering, but at least should properly report in console which pairs failed.